### PR TITLE
Add HACS configuration and improve API handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This repository provides a Home Assistant custom card for displaying wind data from [ksnoordwijkwind.nl](https://www.ksnoordwijkwind.nl/currentwind).
 
-Place `wind-card.js` in your Home Assistant `www` directory and add it as a resource:
+Place `wind-card.js` in your Home Assistant `www` directory or install it via HACS.
+If you use [HACS](https://hacs.xyz/) copy this repository's URL in the "Custom repositories" section and select the "Plugin" category.
+After installation add it as a resource:
 
 ```yaml
 resources:
@@ -17,4 +19,6 @@ type: custom:wind-card
 ```
 
 The card fetches new data every 15 seconds and animates wind speed, gusts and direction using the `timeLineLast15sec` data from the API.
+It understands both the original `windKn`/`gustKn`/`windDir` fields and the alternative
+`wind`/`vlagen`/`richting` names found in some responses.
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Wind Card",
+  "render_readme": true,
+  "filename": "wind-card.js",
+  "type": "js"
+}

--- a/wind-card.js
+++ b/wind-card.js
@@ -42,9 +42,9 @@ class WindCard extends LitElement {
     try {
       const res = await fetch('https://www.ksnoordwijkwind.nl/currentwind');
       const data = await res.json();
-      this.windSpeed = data.windKn;
-      this.gust = data.gustKn;
-      this.direction = data.windDir;
+      this.windSpeed = data.windKn ?? data.wind ?? 0;
+      this.gust = data.gustKn ?? data.vlagen ?? 0;
+      this.direction = data.windDir ?? data.richting ?? data.direction ?? 0;
       this.dateTime = data.dateTime;
       this.isLive = data.isLive;
       this._timeline = data.timeLineLast15sec || [];
@@ -59,9 +59,10 @@ class WindCard extends LitElement {
     if (!this._timeline || this._timeline.length === 0) return;
     const frame = this._timeline[this._timelineIndex];
     if (frame) {
-      this.windSpeed = frame.windKn;
-      this.gust = frame.gustKn;
-      this.direction = frame.windDir;
+      this.windSpeed = frame.windKn ?? frame.wind ?? this.windSpeed;
+      this.gust = frame.gustKn ?? frame.vlagen ?? this.gust;
+      this.direction =
+        frame.windDir ?? frame.richting ?? frame.direction ?? this.direction;
     }
     this._timelineIndex = (this._timelineIndex + 1) % this._timeline.length;
   }


### PR DESCRIPTION
## Summary
- add `hacs.json` so the card can be installed via HACS
- describe HACS usage in README
- support both old and new API field names in the JS card

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68639fe3c51c832883552ce88321f063