### PR TITLE
Add config options for wind card visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,23 @@ entity: sensor.my_wind
 ```
 The entity should have a `data` attribute with arrays named `direction`, `speed` and `gusts`. The card cycles through these values once per second.
 
+### Configuration Options
+Additional options allow tweaking the visuals:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `marker_diameter` | Diameter of the outer marker circle (tick marks) in SVG units | `100` |
+| `graph_diameter`  | Diameter of the radial speed/gust graphs | `70` |
+| `arrow_offset`    | Distance from the card center to the base of the arrow | `40` |
+
+Example usage:
+```yaml
+type: custom:wind-card
+entity: sensor.my_wind
+marker_diameter: 80
+graph_diameter: 60
+arrow_offset: 35
+```
+
 If you see `i.setConfig is not a function`, Home Assistant could not load the script. Ensure the resource URL above is present and refresh the browser.
 

--- a/wind-card.js
+++ b/wind-card.js
@@ -45,7 +45,11 @@ class WindCard extends LitElement {
     if (!config.entity) {
       throw new Error('Entity is required');
     }
-    this.config = config;
+    this.config = Object.assign({
+      marker_diameter: 100,
+      graph_diameter: 70,
+      arrow_offset: 40,
+    }, config);
   }
 
   set hass(hass) {
@@ -144,7 +148,8 @@ class WindCard extends LitElement {
         font-size: 0.75em;
       }
       .info .speed {
-        font-size: 1.4em;
+        font-size: 3.5em;
+        font-weight: 800;
         line-height: 1;
       }
       .date {
@@ -155,6 +160,9 @@ class WindCard extends LitElement {
       }
       .compass {
         transition: transform 1s linear;
+        -webkit-transition: -webkit-transform 1s linear;
+        transform-box: fill-box;
+        transform-origin: center;
       }
       .ring text {
         fill: var(--primary-text-color, #212121);
@@ -165,11 +173,15 @@ class WindCard extends LitElement {
 
   render() {
     const dirText = this._directionToText(this.direction);
-    const majorPath = this._buildTickPath(50, 6, 30, [0, 90, 180, 270]);
-    const minorPath = this._buildTickPath(50, 3, 5, [355,0,5,85,90,95,175,180,185,265,270,275]);
+    const markerDiameter = this.config.marker_diameter ?? 100;
+    const markerRadius = markerDiameter / 2;
+    const arrowOffset = this.config.arrow_offset ?? 40;
+    const majorPath = this._buildTickPath(markerRadius, 6, 30, [0, 90, 180, 270]);
+    const minorPath = this._buildTickPath(markerRadius, 3, 5, [355,0,5,85,90,95,175,180,185,265,270,275]);
 
     const maxSpeed = 60;
-    const radius = 35;
+    const graphDiameter = this.config.graph_diameter ?? 70;
+    const radius = graphDiameter / 2;
     const circumference = 2 * Math.PI * radius;
     const speedOffset = circumference * (1 - Math.min(this.windSpeed, maxSpeed) / maxSpeed);
     const gustOffset = circumference * (1 - Math.min(this.gust, maxSpeed) / maxSpeed);
@@ -211,16 +223,16 @@ class WindCard extends LitElement {
             opacity="0.6"
           ></circle>
           <g class="ring">
-            <text class="compass cardinal" text-anchor="middle" alignment-baseline="central" x="50" y="94" font-size="11">S</text>
-            <text class="compass cardinal" text-anchor="middle" alignment-baseline="central" x="6" y="50" font-size="11">W</text>
-            <text class="compass cardinal" text-anchor="middle" alignment-baseline="central" x="50" y="6" font-size="11">N</text>
-            <text class="compass cardinal" text-anchor="middle" alignment-baseline="central" x="94" y="50" font-size="11">E</text>
+            <text class="compass cardinal" text-anchor="middle" alignment-baseline="central" x="50" y="${50 + markerRadius - 6}" font-size="11">S</text>
+            <text class="compass cardinal" text-anchor="middle" alignment-baseline="central" x="${50 - markerRadius + 6}" y="50" font-size="11">W</text>
+            <text class="compass cardinal" text-anchor="middle" alignment-baseline="central" x="50" y="${50 - markerRadius + 6}" font-size="11">N</text>
+            <text class="compass cardinal" text-anchor="middle" alignment-baseline="central" x="${50 + markerRadius - 6}" y="50" font-size="11">E</text>
             <path class="compass major" stroke-width="1.4" fill="none" stroke="var(--primary-text-color, #212121)" stroke-linecap="round" stroke-opacity="1" d="${majorPath}"></path>
             <path class="compass minor" stroke-width="0.8" fill="none" stroke="var(--secondary-text-color, #727272)" stroke-linecap="round" stroke-opacity="1" d="${minorPath}"></path>
           </g>
           <g class="indicators">
-            <g class="marker compass" transform="rotate(${this.direction + 180} 50 50)">
-              <path stroke="var(--card-background-color, white)" stroke-linejoin="bevel" d="M 50 97.333 l 7.36 -12.748 l -7.36 2.453 l -7.36 -2.453 Z" fill="rgb(68,115,158)" stroke-width="0" transform="rotate(180 50 90)"></path>
+            <g class="marker compass" style="transform: rotate(${this.direction + 180}deg);">
+              <path stroke="var(--card-background-color, white)" stroke-linejoin="bevel" d="M 50 ${50 + arrowOffset + 7.333} l 7.36 -12.748 l -7.36 2.453 l -7.36 -2.453 Z" fill="rgb(68,115,158)" stroke-width="0" transform="rotate(180 50 ${50 + arrowOffset})"></path>
             </g>
           </g>
         </svg>


### PR DESCRIPTION
## Summary
- make wind speed text bold and larger
- improve Safari animation support
- add configurable sizes for marker circle, radial graphs and arrow offset
- document new options in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68643dbc00708328bdcbac1d74ce394d