### PR TITLE
Fix Safari arrow animation

### DIFF
--- a/wind-card.js
+++ b/wind-card.js
@@ -158,6 +158,8 @@ class WindCard extends LitElement {
       .compass {
         transition: transform 1s linear;
         -webkit-transition: -webkit-transform 1s linear;
+        transform-origin: 50% 50%;
+        transform-box: fill-box;
       }
       .ring text {
         fill: var(--primary-text-color, #212121);
@@ -223,7 +225,7 @@ class WindCard extends LitElement {
             <path class="compass minor" stroke-width="0.8" fill="none" stroke="var(--secondary-text-color, #727272)" stroke-linecap="round" stroke-opacity="1" d="${minorPath}"></path>
           </g>
           <g class="indicators">
-            <g class="marker compass" transform="rotate(${this.direction + 180} 50 50)">
+            <g class="marker compass" style="transform: rotate(${this.direction + 180}deg);">
               <path stroke="var(--card-background-color, white)" stroke-linejoin="bevel" d="M 50 97 l 9 -15 l -9 3 l -9 -3 Z" fill="rgb(68,115,158)" stroke-width="0" transform="rotate(180 50 90)"></path>
             </g>
           </g>


### PR DESCRIPTION
## Summary
- ensure transform animation on arrow works in Safari

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865a85b740083288ac69f96e112051d