### PR TITLE
Add full ha-card and configurable size

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Add a card of type `custom:wind-card` and point it to an entity containing wind 
 ```yaml
 type: custom:wind-card
 entity: sensor.my_wind
+size: 250
 ```
+The optional `size` parameter controls the width and height of the SVG in pixels.
+If omitted the default size is 200.
 The entity should have a `data` attribute with arrays named `direction`, `speed` and `gusts`. The card cycles through these values once per second.
 
 If you see `i.setConfig is not a function`, Home Assistant could not load the script. Ensure the resource URL above is present and refresh the browser.

--- a/wind-card.js
+++ b/wind-card.js
@@ -9,6 +9,7 @@ class WindCard extends LitElement {
       windSpeed: { type: Number },
       gust: { type: Number },
       direction: { type: Number },
+      size: { type: Number },
       _timeline: { type: Array },
       _timelineIndex: { type: Number }
     };
@@ -21,6 +22,7 @@ class WindCard extends LitElement {
     this.windSpeed = 0;
     this.gust = 0;
     this.direction = 0;
+    this.size = 200;
     this._timeline = [];
     this._timelineIndex = 0;
   }
@@ -40,6 +42,7 @@ class WindCard extends LitElement {
       throw new Error('Entity is required');
     }
     this.config = config;
+    this.size = Number(config.size || 200);
   }
 
   set hass(hass) {
@@ -115,8 +118,6 @@ class WindCard extends LitElement {
       }
       .container {
         position: relative;
-        width: 200px;
-        height: 200px;
         margin: auto;
       }
       svg {
@@ -164,7 +165,8 @@ class WindCard extends LitElement {
     const gustOffset = circumference * (1 - Math.min(this.gust, maxSpeed) / maxSpeed);
 
     return html`
-      <div class="container">
+      <ha-card>
+      <div class="container" style="width:${this.size}px; height:${this.size}px;">
         <svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet" focusable="false" role="img" aria-hidden="true">
           <circle
             cx="50"
@@ -210,6 +212,7 @@ class WindCard extends LitElement {
           <div class="gust">${this.gust.toFixed(1)} kn</div>
         </div>
       </div>
+      </ha-card>
     `;
   }
 }


### PR DESCRIPTION
## Summary
- enable card background via `<ha-card>` wrapper
- add `size` option to set SVG width/height
- document new configuration option

## Testing
- `node --check wind-card.js`


------
https://chatgpt.com/codex/tasks/task_e_68664b745a648328ac3a32a421dd8c84