### PR TITLE
Allow customizing radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Add a card of type `custom:wind-card` and point it to an entity containing wind 
 type: custom:wind-card
 entity: sensor.my_wind
 size: 250
+radius: 40
+cardinal_offset: 4
+radius_tickPath: 38
 ```
-The optional `size` parameter controls the width and height of the SVG in pixels.
-If omitted the default size is 200.
+The optional parameters `size`, `radius`, `cardinal_offset` and `radius_tickPath` control the dimensions of the compass. If omitted their defaults are 200, 40, 4 and 38 respectively.
 The entity should have a `data` attribute with arrays named `direction`, `speed` and `gusts`. The card cycles through these values once per second.

--- a/wind-card.js
+++ b/wind-card.js
@@ -9,6 +9,9 @@ class WindCard extends LitElement {
       gust: { type: Number },
       direction: { type: Number },
       size: { type: Number },
+      radius: { type: Number },
+      cardinal_offset: { type: Number },
+      radius_tickPath: { type: Number },
       _timeline: { type: Array },
       _timelineIndex: { type: Number }
     };
@@ -22,6 +25,9 @@ class WindCard extends LitElement {
     this.gust = 0;
     this.direction = 0;
     this.size = 200;
+    this.radius = 40;
+    this.cardinal_offset = 4;
+    this.radius_tickPath = 38;
     this._timeline = [];
     this._timelineIndex = 0;
   }
@@ -40,6 +46,9 @@ class WindCard extends LitElement {
     if (!config.entity) throw new Error('Entity is required');
     this.config = config;
     this.size = Number(config.size || 200);
+    this.radius = Number(config.radius || 40);
+    this.cardinal_offset = Number(config.cardinal_offset || 4);
+    this.radius_tickPath = Number(config.radius_tickPath || 38);
   }
 
   set hass(hass) {
@@ -160,9 +169,9 @@ class WindCard extends LitElement {
   render() {
     const dirText = this._directionToText(this.direction);
     const maxSpeed = 60;
-    const radius = 40;
-    const radius_tickPath = 38
-    const cardinal_offset = 4;
+    const radius = this.radius;
+    const radius_tickPath = this.radius_tickPath;
+    const cardinal_offset = this.cardinal_offset;
     const majorPath = this._buildTickPath(radius_tickPath, 3.5, 30, [0, 90, 180, 270]);
     const minorPath = this._buildTickPath(radius_tickPath, 1.5, 5, [355, 0, 5, 85, 90, 95, 175, 180, 185, 265, 270, 275]);
     const circumference = 2 * Math.PI * radius;


### PR DESCRIPTION
## Summary
- allow customizing compass radius, tick path radius and cardinal text offset via card config
- document new options in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866d8f59a208328a62048ebf14ed765