### PR TITLE
Fix Safari rotation

### DIFF
--- a/wind-card.js
+++ b/wind-card.js
@@ -167,6 +167,8 @@ class WindCard extends LitElement {
       }
       .marker {
         transition: transform 1s linear;
+        transform-origin: 50% 50%;
+        transform-box: view-box;
       }
       .ring text {
         fill: var(--primary-text-color, #212121);
@@ -337,7 +339,7 @@ class WindCard extends LitElement {
               <path class="compass marker" stroke="var(--card-background-color, white)" stroke-linejoin="bevel"
                 d="m 50,${tickPath_radius + 46} l 5,3 l -5,-12 l -5,12 z"
                 fill="var(--primary-color)" stroke-width="0"
-                transform="rotate(${this.direction + 180},50,50)">
+                style="transform: rotate(${this.direction + 180}deg);">
               </path>
             </g>
 


### PR DESCRIPTION
## Summary
- set SVG transform origin for marker to center of the viewbox
- use CSS transform on the direction arrow for smoother animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867bb7463c083289327ac9166f837cc