### PR TITLE
Add graph toggle and hover gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Wind Card is a [Home Assistant](https://www.home-assistant.io/) custom card for 
 - Animated direction arrow with radial speed and gust rings
 - Wind rose with N/E/S/W indicators and tick marks
 - Cycles through arrays of `direction`, `speed` and `gusts` exposed in an entity's `data` attribute
+- Hovering over the history bars displays that entry's values on the gauge
 
 ## Installation
 ### With HACS
@@ -44,8 +45,10 @@ tickPath_width: 4
 units_offset: 4
 minutes: 30
 graph_height: 100
+show_graph: true
 autoscale: true
 multiplier: 1
 ```
 The optional parameters `size`, `gauge_radius`, `gauge_width`, `cardinal_offset`, `tickPath_radius`, `tickPath_width` and `units_offset` control the dimensions of the compass. If omitted their defaults are 200, 40, 2, 4, 38, 4 and 4 respectively.
 `minutes` controls how much history (in minutes) is displayed. `graph_height` sets the height of the bar chart. If `autoscale` is `true` the graph scales to the maximum gust value; otherwise values are scaled by `multiplier`.
+Set `show_graph` to `false` to hide the bar chart entirely.


### PR DESCRIPTION
## Summary
- allow hiding the history graph with new `show_graph` config option
- display values from a bar in the gauge when hovering over that bar
- document new option and hover behaviour

## Testing
- `node -c wind-card.js`

------
https://chatgpt.com/codex/tasks/task_e_68764edd04348328930b403922f46275