### PR TITLE
Remove direction icons from graph bars

### DIFF
--- a/wind-card.js
+++ b/wind-card.js
@@ -478,7 +478,6 @@ class WindCard extends LitElement {
           <div class="date-wind-bar-segment" style="background:${colorWind};height:${windHeight}px;width:100%;"></div>
           ${gustHeight > 0 ? html`<div class="date-gust-bar-segment" style="background:${colorGust};height:1px;margin-bottom:${gustHeight}px;width:100%;"></div>` : null}
         </div>
-        <ha-icon class="dir-icon" icon="mdi:navigation" style="--mdc-icon-size: 100%; transform: rotate(${direction + 180}deg);"></ha-icon>
       </div>`;
   }
 
@@ -622,10 +621,6 @@ class WindCard extends LitElement {
       flex-direction: column-reverse;
       align-items: stretch;
       transition: height 0.6s ease;
-    }
-    .dir-icon {
-      pointer-events: none;
-      transform-origin: center center;
     }
     .h-line {
       position: absolute;


### PR DESCRIPTION
## Summary
- drop the navigation icons below each history bar
- remove the related CSS styling

## Testing
- `node --check wind-card.js`

------
https://chatgpt.com/codex/tasks/task_e_6880a794585883289e045f0f36772534