### PR TITLE
Add dynamic minute tick marks

### DIFF
--- a/wind-card.js
+++ b/wind-card.js
@@ -477,6 +477,31 @@ class WindCard extends LitElement {
       </div>`;
   }
 
+  _renderMinuteTicks() {
+    if (!Array.isArray(this._data) || this._data.length === 0) {
+      return null;
+    }
+    const now = new Date();
+    const radius = this.tickPath_radius;
+    const maxSpeed = 60;
+    const lines = [];
+    const dataCount = Math.min(60, this._data.length);
+    for (let i = 0; i < dataCount; i++) {
+      const idx = this._data.length - 1 - i;
+      const d = this._data[idx];
+      if (!d) continue;
+      const minute = (now.getMinutes() - i + 60) % 60;
+      const angle = minute * 6;
+      const len = (d.wind / maxSpeed) * this.tickPath_width;
+      const outer = this._polarToCartesian(50, 50, radius, angle);
+      const inner = this._polarToCartesian(50, 50, radius - len, angle);
+      const color = this._speedToColor(d.wind);
+      const opacity = i >= 50 ? 1 - (i - 50) / 10 : 1;
+      lines.push(svg`<path d="M ${inner.x},${inner.y} L ${outer.x},${outer.y}" stroke="${color}" stroke-width="3" stroke-linecap="round" opacity="${opacity}"></path>`);
+    }
+    return lines;
+  }
+
   render() {
     const dirText = this._directionToText(this.direction);
     const maxSpeed = 60;
@@ -499,6 +524,9 @@ class WindCard extends LitElement {
           <svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet" focusable="false" role="img" aria-hidden="true">
             <circle cx="50" cy="50" r="${radius}" fill="none" stroke="${gustColor}" stroke-width="${this.gauge_width}" stroke-dasharray="${circumference}" stroke-dashoffset="${gustOffset}" style="transition: stroke-dashoffset 1s ease-in-out, stroke 1s ease-in-out;" transform="rotate(-90 50 50)" opacity="1"></circle>
             <circle cx="50" cy="50" r="${radius}" fill="none" stroke="${windColor}" stroke-width="${this.gauge_width}" stroke-dasharray="${circumference}" stroke-dashoffset="${speedOffset}" style="transition: stroke-dashoffset 1s ease-in-out, stroke 1s ease-in-out;" transform="rotate(-90 50 50)" opacity="1"></circle>
+            <g class="minute-ticks">
+              ${this._renderMinuteTicks()}
+            </g>
             <g class="ring">
               <text class="compass cardinal" text-anchor="middle" alignment-baseline="central" x="50" y="${50 - tickPath_radius + cardinal_offset}" font-size="11">N</text>
               <text class="compass cardinal" text-anchor="middle" alignment-baseline="central" x="${50 + tickPath_radius - cardinal_offset}" y="50" font-size="11">E</text>
@@ -577,6 +605,9 @@ class WindCard extends LitElement {
     .ring text {
       fill: var(--primary-text-color, #212121);
       font-weight: bold;
+    }
+    .minute-ticks path {
+      transition: stroke 0.6s ease, opacity 0.6s ease;
     }
     text {
       fill: var(--primary-text-color, #212121);


### PR DESCRIPTION
## Summary
- show latest 60 minutes around the compass with minute tick marks
- colour and length of each tick show wind speed
- fade the oldest 10 minutes

## Testing
- `node -e "require('./wind-card.js')"` *(fails: ERR_NETWORK_IMPORT_DISALLOWED)*

------
https://chatgpt.com/codex/tasks/task_e_6880ca2badcc8328b071b0004a56b8c5